### PR TITLE
Use wp_safe_remote_get to retrieve geoplugin data

### DIFF
--- a/simple-download-monitor/includes/sdm-utility-functions.php
+++ b/simple-download-monitor/includes/sdm-utility-functions.php
@@ -108,7 +108,8 @@ function sdm_ip_info($ip, $purpose = "location") {
         "SA" => "South America"
     );
 
-    $ipdat = @json_decode(file_get_contents("http://www.geoplugin.net/json.gp?ip=" . $ip));
+    $res = wp_safe_remote_get("http://www.geoplugin.net/json.gp?ip=" . $ip);
+    $ipdat = @json_decode($res['body']);
 
     if (@strlen(trim($ipdat->geoplugin_countryCode)) === 2) {
         switch ($purpose) {

--- a/simple-download-monitor/includes/sdm-utility-functions.php
+++ b/simple-download-monitor/includes/sdm-utility-functions.php
@@ -109,6 +109,9 @@ function sdm_ip_info($ip, $purpose = "location") {
     );
 
     $res = wp_safe_remote_get("http://www.geoplugin.net/json.gp?ip=" . $ip);
+    if ( is_wp_error($res) ) {
+        return null;
+    }    
     $ipdat = @json_decode($res['body']);
 
     if (@strlen(trim($ipdat->geoplugin_countryCode)) === 2) {

--- a/simple-download-monitor/includes/sdm-utility-functions.php
+++ b/simple-download-monitor/includes/sdm-utility-functions.php
@@ -108,11 +108,7 @@ function sdm_ip_info($ip, $purpose = "location") {
         "SA" => "South America"
     );
 
-    $res = wp_safe_remote_get("http://www.geoplugin.net/json.gp?ip=" . $ip);
-    if ( is_wp_error($res) ) {
-        return null;
-    }    
-    $ipdat = @json_decode($res['body']);
+    $ipdat = @json_decode(file_get_contents("http://www.geoplugin.net/json.gp?ip=" . $ip));
 
     if (@strlen(trim($ipdat->geoplugin_countryCode)) === 2) {
         switch ($purpose) {

--- a/simple-download-monitor/includes/templates/fancy1/sdm-fancy-1.php
+++ b/simple-download-monitor/includes/templates/fancy1/sdm-fancy-1.php
@@ -3,23 +3,11 @@
 function sdm_generate_fancy1_latest_downloads_display_output($get_posts, $args) {
 
     $output = "";
-    isset($args['button_text']) ? $button_text = $args['button_text'] : $button_text = '';
-    isset($args['new_window']) ? $new_window = $args['new_window'] : $new_window = '';
-    isset($args['show_size']) ? $show_size = $args['show_size'] : $show_size = '';
-    isset($args['show_version']) ? $show_version = $args['show_version'] : $show_version = '';
     
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '1',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'show_size' => $show_size,
-            'show_version' => $show_version,
+        $output .= sdm_generate_fancy1_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy1_display_output($args);
     }
     $output .= '<div class="sdm_clear_float"></div>';
     return $output;
@@ -32,23 +20,10 @@ function sdm_generate_fancy1_category_display_output($get_posts, $args) {
     //TODO - when the CSS file is moved to the fancy1 folder, change it here
     //$output .= '<link type="text/css" rel="stylesheet" href="' . WP_SIMPLE_DL_MONITOR_URL . '/includes/templates/fancy1/sdm-fancy-1-styles.css?ver=' . WP_SIMPLE_DL_MONITOR_VERSION . '" />';
     
-    isset($args['button_text']) ? $button_text = $args['button_text'] : $button_text = '';
-    isset($args['new_window']) ? $new_window = $args['new_window'] : $new_window = '';
-    isset($args['show_size']) ? $show_size = $args['show_size'] : $show_size = '';
-    isset($args['show_version']) ? $show_version = $args['show_version'] : $show_version = '';
-    
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '1',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'show_size' => $show_size,
-            'show_version' => $show_version,            
+        $output .= sdm_generate_fancy1_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy1_display_output($args);
     }
     $output .= '<div class="sdm_clear_float"></div>';
     return $output;
@@ -60,9 +35,19 @@ function sdm_generate_fancy1_category_display_output($get_posts, $args) {
  * id, fancy, button_text, new_window
  */
 
-function sdm_generate_fancy1_display_output($args) {
+function sdm_generate_fancy1_display_output($atts) {
 
-    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts($args);
+    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts(
+        shortcode_atts(array(
+            'id' => '',
+            'button_text' => __('Download Now!', 'simple-download-monitor'),
+            'new_window' => '',
+            'color' => '',
+            'css_class' => '',
+            'show_size' => '',
+            'show_version' => '',
+        ), $atts)
+    );
 
     // Make shortcode attributes available in function local scope.
     extract($shortcode_atts);
@@ -95,11 +80,11 @@ function sdm_generate_fancy1_display_output($args) {
 
     //Get item file size
     $item_file_size = get_post_meta($id, 'sdm_item_file_size', true);
-    $isset_item_file_size = (isset($args['show_size']) && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
+    $isset_item_file_size = ($show_size && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
 
     //Get item version
     $item_version = get_post_meta($id, 'sdm_item_version', true);
-    $isset_item_version = (isset($args['show_version']) && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
+    $isset_item_version = ($show_version && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
 
     // Check to see if the download link cpt is password protected
     $get_cpt_object = get_post($id);
@@ -111,8 +96,6 @@ function sdm_generate_fancy1_display_output($args) {
     $db_count = sdm_get_download_count_for_post($id);
     $string = ($db_count == '1') ? __('Download', 'simple-download-monitor') : __('Downloads', 'simple-download-monitor');
     $download_count_string = '<span class="sdm_item_count_number">' . $db_count . '</span><span class="sdm_item_count_string"> ' . $string . '</span>';
-
-    $css_class = isset($args['css_class']) ? $args['css_class'] : '';
 
     $output = '';
 

--- a/simple-download-monitor/includes/templates/fancy2/sdm-fancy-2.php
+++ b/simple-download-monitor/includes/templates/fancy2/sdm-fancy-2.php
@@ -10,23 +10,9 @@ function sdm_generate_fancy2_latest_downloads_display_output($get_posts, $args) 
     $count = 1;
     //$output .= '<ul class="sdm_fancy2_category_items">';
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        $button_text = isset($args['button_text'])? $args['button_text'] : '';
-        $new_window = isset($args['new_window'])? $args['new_window'] : '';
-        $show_size = isset($args['show_size'])? $args['show_size'] : '';
-        $show_version = isset($args['show_version'])? $args['show_version'] : '';
-    
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '2',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'css_class' => 'sdm_fancy2_grid',
-            'show_size' => $show_size,
-            'show_version' => $show_version,            
+        $output .= sdm_generate_fancy2_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy2_display_output($args);
 
         if ($count % 3 == 0) {//Clear after every 3 items in the grid
             $output .= '<div class="sdm_clear_float"></div>';
@@ -46,23 +32,9 @@ function sdm_generate_fancy2_category_display_output($get_posts, $args) {
     $count = 1;
     //$output .= '<ul class="sdm_fancy2_category_items">';
     foreach ($get_posts as $item) {
-        $id = $item->ID;  //Get the post ID
-        $button_text = isset($args['button_text'])? $args['button_text'] : '';
-        $new_window = isset($args['new_window'])? $args['new_window'] : '';
-        $show_size = isset($args['show_size'])? $args['show_size'] : '';
-        $show_version = isset($args['show_version'])? $args['show_version'] : '';
-        
-        //Create a args array
-        $args = array(
-            'id' => $id,
-            'fancy' => '2',
-            'button_text' => $button_text,
-            'new_window' => $new_window,
-            'css_class' => 'sdm_fancy2_grid',
-            'show_size' => $show_size,
-            'show_version' => $show_version,            
+        $output .= sdm_generate_fancy2_display_output(
+            array_merge($args, array('id' => $item->ID))
         );
-        $output .= sdm_generate_fancy2_display_output($args);
 
         if ($count % 3 == 0) {//Clear after every 3 items in the grid
             $output .= '<div class="sdm_clear_float"></div>';
@@ -80,9 +52,19 @@ function sdm_generate_fancy2_category_display_output($get_posts, $args) {
  * id, fancy, button_text, new_window
  */
 
-function sdm_generate_fancy2_display_output($args) {
+function sdm_generate_fancy2_display_output($atts) {
 
-    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts($args);
+    $shortcode_atts = sanitize_sdm_create_download_shortcode_atts(
+        shortcode_atts(array(
+            'id' => '',
+            'button_text' => __('Download Now!', 'simple-download-monitor'),
+            'new_window' => '',
+            'color' => '',
+            'css_class' => 'sdm_fancy2_grid',
+            'show_size' => '',
+            'show_version' => '',
+        ), $atts)
+    );
 
     // Make shortcode attributes available in function local scope.
     extract($shortcode_atts);
@@ -118,14 +100,13 @@ function sdm_generate_fancy2_display_output($args) {
 
     //Get item file size
     $item_file_size = get_post_meta($id, 'sdm_item_file_size', true);
-    $isset_item_file_size = (isset($args['show_size']) && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
+    $isset_item_file_size = ($show_size && isset($item_file_size)) ? $item_file_size : '';//check if show_size is enabled and if there is a size value
 
     //Get item version
     $item_version = get_post_meta($id, 'sdm_item_version', true);
-    $isset_item_version = (isset($args['show_version']) && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
+    $isset_item_version = ($show_version && isset($item_version)) ? $item_version : '';//check if show_version is enabled and if there is a version value
 
     
-    $css_class = isset($args['css_class']) ? $args['css_class'] : '';
     $output = '';
     $output .= '<div class="sdm_fancy2_item ' . $css_class . '">';
     $output .= '<div class="sdm_fancy2_wrapper">';

--- a/simple-download-monitor/main.php
+++ b/simple-download-monitor/main.php
@@ -3,7 +3,7 @@
 * Plugin Name: Simple Download Monitor
 * Plugin URI: https://www.tipsandtricks-hq.com/simple-wordpress-download-monitor-plugin
 * Description: Easily manage downloadable files and monitor downloads of your digital files from your WordPress site.
-* Version: 3.3.5
+* Version: 3.3.6
 * Author: Tips and Tricks HQ, Ruhul Amin, Josh Lobe
 * Author URI: https://www.tipsandtricks-hq.com/development-center
 * License: GPL2
@@ -13,7 +13,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('WP_SIMPLE_DL_MONITOR_VERSION', '3.3.5');
+define('WP_SIMPLE_DL_MONITOR_VERSION', '3.3.6');
 define('WP_SIMPLE_DL_MONITOR_DIR_NAME', dirname(plugin_basename(__FILE__)));
 define('WP_SIMPLE_DL_MONITOR_URL', plugins_url('', __FILE__));
 define('WP_SIMPLE_DL_MONITOR_PATH', plugin_dir_path(__FILE__));

--- a/simple-download-monitor/readme.txt
+++ b/simple-download-monitor/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.tipsandtricks-hq.com
 Tags: download, downloads, count, counter, tracker, tracking, hits, logging, monitor, manager, files, media, digital, download monitor, download manager, downloadmanager, file manager, protect downloads, password, download category, file tree, ajax, download template, grid, documents, ip address
 Requires at least: 4.1.0
 Tested up to: 4.6
-Stable tag: 3.3.5
+Stable tag: 3.3.6
 License: GPLv2 or later
 
 Easily manage downloadable files and monitor downloads of your digital files from your WordPress site.
@@ -169,6 +169,9 @@ Yes
 For screenshots please visit the [download monitor plugin page](https://www.tipsandtricks-hq.com/simple-wordpress-download-monitor-plugin)
 
 == Changelog ==
+
+= 3.3.6 =
+- Fix fancy template shortcode attributes: some shortcode attributes were ignored in the previous release.
 
 = 3.3.5 =
 - Download button color can now be specified in the shortcode for fancy 1 and the standard download button.


### PR DESCRIPTION
Using file_get_contents($url) won't work if your Wordpress server requires an HTTP Proxy to reach the Internet, e.g. if it (the Wordpress server) has a private IP address.

wp_safe_remote_get uses Wordpress's built-in HTTP client, which is aware of constants like WP_PROXY_HOST and WP_PROXY_PORT.
